### PR TITLE
support oneOf

### DIFF
--- a/lib/openapi2ruby/openapi/schema.rb
+++ b/lib/openapi2ruby/openapi/schema.rb
@@ -39,7 +39,6 @@ module Openapi2ruby
       return [] if properties.empty?
       properties.each_with_object([]) do |value, results|
         if value.one_of?
-          p value
           results << value.one_of_refs
         else
           results

--- a/lib/openapi2ruby/openapi/schema.rb
+++ b/lib/openapi2ruby/openapi/schema.rb
@@ -34,5 +34,17 @@ module Openapi2ruby
       return false if requireds.nil?
       requireds.include?(property.name)
     end
+
+    def one_ofs
+      return [] if properties.empty?
+      properties.each_with_object([]) do |value, results|
+        if value.one_of?
+          p value
+          results << value.one_of_refs
+        else
+          results
+        end
+      end
+    end
   end
 end

--- a/lib/openapi2ruby/openapi/schema/property.rb
+++ b/lib/openapi2ruby/openapi/schema/property.rb
@@ -8,6 +8,14 @@ module Openapi2ruby
       @items = content[:definition]['items']
       @format = content[:definition]['format']
       @ref = content[:definition]['$ref']
+      if content[:definition]['oneOf']
+        @type = 'oneOf'
+        @one_of_refs = content[:definition]['oneOf'].map do |content|
+          content['$ref'].split('/').last
+        end
+      else
+        @one_of_items = []
+      end
     end
 
     # OpenAPI schema ref property name
@@ -38,8 +46,18 @@ module Openapi2ruby
     # OpenAPI schema property types
     # @return [Array[Class]]
     def types
+      return [Hash] if one_of?
       return [ref] if @type.nil?
+
       converted_types
+    end
+
+    def one_of?
+      @type == 'oneOf' && !@one_of_refs.empty?
+    end
+
+    def one_of_refs
+      @one_of_refs
     end
 
     private

--- a/lib/openapi2ruby/templates/serializer.rb.erb
+++ b/lib/openapi2ruby/templates/serializer.rb.erb
@@ -20,7 +20,11 @@ class <%= @schema.name %>Serializer < ActiveModel::Serializer
     required_check(<%= ":#{p.name}" %>)
     <%- end %>
     type_check(<%= ":#{p.name}, #{p.types}" -%>)
+    <%- if p.one_of? -%>
+    one_of_<%=- p.name %>(object.<%=- p.name %>)
+    <%- else -%>
     object.<%=- p.name %>
+    <%- end -%>
   end
   <%- end %>
   private
@@ -32,4 +36,16 @@ class <%= @schema.name %>Serializer < ActiveModel::Serializer
   def type_check(name, types)
     raise "Field type is invalid. #{name}" unless types.include?(object.send(name).class)
   end
+  <%- @schema.properties.select{ |p| p.one_of? }.each do |p| %>
+  def one_of_<%=- p.name %>(one_of_value)
+    case one_of_value.class
+    <%- p.one_of_refs.each do |ref| -%>
+    when <%= ref -%> then
+      <%= ref -%>Serializer.new(one_of_value).attributes
+    <%- end -%>
+    else
+      raise "Failed to serialize as one_of ref: #{one_of_value}"
+    end
+  end
+  <%- end -%>
 end

--- a/lib/openapi2ruby/templates/serializer.rb.erb
+++ b/lib/openapi2ruby/templates/serializer.rb.erb
@@ -25,11 +25,9 @@ class <%= @schema.name %>Serializer < ActiveModel::Serializer
       <%= ref -%>,
     <%- end -%>
     ])
-
     one_of_<%=- p.name %>(object.<%=- p.name %>)
     <%- else -%>
     type_check(<%= ":#{p.name}, #{p.types}" -%>)
-
     object.<%=- p.name %>
     <%- end -%>
   end

--- a/lib/openapi2ruby/templates/serializer.rb.erb
+++ b/lib/openapi2ruby/templates/serializer.rb.erb
@@ -19,10 +19,17 @@ class <%= @schema.name %>Serializer < ActiveModel::Serializer
     <%- if @schema.required?(p) %>
     required_check(<%= ":#{p.name}" %>)
     <%- end %>
-    type_check(<%= ":#{p.name}, #{p.types}" -%>)
     <%- if p.one_of? -%>
+    type_check(<%= ":#{p.name}"-%>, [
+    <%- p.one_of_refs.map do |ref| -%>
+      <%= ref -%>,
+    <%- end -%>
+    ])
+
     one_of_<%=- p.name %>(object.<%=- p.name %>)
     <%- else -%>
+    type_check(<%= ":#{p.name}, #{p.types}" -%>)
+
     object.<%=- p.name %>
     <%- end -%>
   end
@@ -38,7 +45,7 @@ class <%= @schema.name %>Serializer < ActiveModel::Serializer
   end
   <%- @schema.properties.select{ |p| p.one_of? }.each do |p| %>
   def one_of_<%=- p.name %>(one_of_value)
-    case one_of_value.class
+    case one_of_value
     <%- p.one_of_refs.each do |ref| -%>
     when <%= ref -%> then
       <%= ref -%>Serializer.new(one_of_value).attributes

--- a/spec/fixtures/files/oneof.yaml
+++ b/spec/fixtures/files/oneof.yaml
@@ -1,0 +1,80 @@
+# This yaml referenced OpenAPI-Specification
+# https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: oneof example
+  license:
+    name: MIT
+paths:
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        animal:
+          oneOf:
+            - $ref: '#/components/schemas/Cat'
+            - $ref: '#/components/schemas/Dog'
+        name:
+          type: string
+        tag:
+          type: string
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/spec/fixtures/files/pet_serializer_oneof.rb
+++ b/spec/fixtures/files/pet_serializer_oneof.rb
@@ -37,7 +37,7 @@ class PetSerializer < ActiveModel::Serializer
   end
 
   def one_of_animal(one_of_value)
-    case one_of_value.class
+    case one_of_value
     when Cat then
       CatSerializer.new(one_of_value).attributes
     when Dog then

--- a/spec/fixtures/files/pet_serializer_oneof.rb
+++ b/spec/fixtures/files/pet_serializer_oneof.rb
@@ -1,0 +1,49 @@
+class PetSerializer < ActiveModel::Serializer
+  attributes :id, :name, :animal, :tag
+
+
+  def id
+    required_check(:id)
+
+    type_check(:id, [Integer])
+    object.id
+  end
+
+  def name
+    required_check(:name)
+
+    type_check(:name, [String])
+    object.name
+  end
+
+  def animal
+    type_check(:animal, [Hash])
+    one_of_animal(object.animal)
+  end
+
+  def tag
+    type_check(:tag, [String])
+    object.tag
+  end
+
+  private
+
+  def required_check(name)
+    raise "Required field is nil. #{name}" if object.send(name).nil?
+  end
+
+  def type_check(name, types)
+    raise "Field type is invalid. #{name}" unless types.include?(object.send(name).class)
+  end
+
+  def one_of_animal(one_of_value)
+    case one_of_value.class
+    when Cat then
+      CatSerializer.new(one_of_value).attributes
+    when Dog then
+      DogSerializer.new(one_of_value).attributes
+    else
+      raise "Failed to serialize as one_of ref: #{one_of_value}"
+    end
+  end
+end

--- a/spec/fixtures/files/pet_serializer_oneof.rb
+++ b/spec/fixtures/files/pet_serializer_oneof.rb
@@ -17,7 +17,10 @@ class PetSerializer < ActiveModel::Serializer
   end
 
   def animal
-    type_check(:animal, [Hash])
+    type_check(:animal, [
+      Cat,
+      Dog,
+    ])
     one_of_animal(object.animal)
   end
 

--- a/spec/openapi2ruby/oneof_spec.rb
+++ b/spec/openapi2ruby/oneof_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe Openapi2ruby::Generator do
+  let(:generator) { Openapi2ruby::Generator.new(schema) }
+  let(:schema) { Openapi2ruby::Parser.parse(schema_path).schemas.first }
+  let(:schema_path) { 'spec/fixtures/files/oneof.yaml' }
+  let(:output_path) { 'spec/tmp' }
+
+  describe '#generate' do
+    let(:generated_file) { "#{output_path}/pet_serializer.rb" }
+    let(:file_fixture) { 'spec/fixtures/files/pet_serializer_oneof.rb' }
+
+    before { generator.generate(output_path, nil) }
+
+    it 'generates serializer class' do
+      expect(File.exist?(generated_file)).to be true
+      expect(FileUtils.cmp(generated_file, file_fixture)).to be true
+    end
+  end
+end


### PR DESCRIPTION
I implemented OpenAPI `oneOf` keyword. 

Specification of `oneOf` is here.
https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/

This fix demands that oneOf object`s class name is same as OpenAPI component object name. If you have some opinion about this, please tell me.

